### PR TITLE
Allow result types to have type parameters

### DIFF
--- a/src/main/scala/com/github/tkawachi/doctest/CommentParser.scala
+++ b/src/main/scala/com/github/tkawachi/doctest/CommentParser.scala
@@ -52,7 +52,7 @@ object CommentParser extends RegexParsers {
 
   def replContLine(leading: String) = leading ~> REPL_CONT_PROMPT ~> ".*".r <~ eol
 
-  def replExpectedLine(leading: String) = leading ~> "res\\d+: \\w+ = ".r ~> ".+".r <~ eol
+  def replExpectedLine(leading: String) = leading ~> "res\\d+: [^=\\n\\r]+ = ".r ~> ".+".r <~ eol
 
   lazy val replExample = replLine >> {
     case leading ~ posFirstLine =>

--- a/src/test/scala/com/github/tkawachi/doctest/CommentParserSpec.scala
+++ b/src/test/scala/com/github/tkawachi/doctest/CommentParserSpec.scala
@@ -101,6 +101,14 @@ class CommentParserSpec extends FunSpec with Matchers {
         """.stripMargin
       parse(comment).get should equal(List(Import("import abc.def")))
     }
+
+    it("parses a result with a parametric type") {
+      val comment =
+        """ * scala> List(1)
+          | * res1: List[Int] = List(1)
+        """.stripMargin
+      parse(comment).get should equal(List(Example("List(1)", "List(1)", 1)))
+    }
   }
 
   describe("Property based") {


### PR DESCRIPTION
This "fixes" the parser in the simplest possible way such that it allows anything between the colon and the equals sign. This fails on function types (e.g. `Int => Int`) but it is good enough for my needs. Fixes #11.
