### PR TITLE
Support val and var statements

### DIFF
--- a/src/main/scala/com/github/tkawachi/doctest/DoctestComponent.scala
+++ b/src/main/scala/com/github/tkawachi/doctest/DoctestComponent.scala
@@ -3,4 +3,4 @@ package com.github.tkawachi.doctest
 sealed abstract class DoctestComponent
 case class Example(expr: String, expected: TestResult, line: Int) extends DoctestComponent
 case class Prop(prop: String, line: Int) extends DoctestComponent
-case class Import(importLine: String) extends DoctestComponent
+case class VerbatimLine(line: String) extends DoctestComponent

--- a/src/main/scala/com/github/tkawachi/doctest/ScalaTestGen.scala
+++ b/src/main/scala/com/github/tkawachi/doctest/ScalaTestGen.scala
@@ -43,7 +43,7 @@ object ScalaTestGen extends TestGen {
            |        $prop
            |      }
            |    }""".stripMargin
-      case Import(line) =>
+      case VerbatimLine(line) =>
         s"    $line"
     }
   }

--- a/src/sbt-test/sbt-doctest/simple/src/main/scala/Main.scala
+++ b/src/sbt-test/sbt-doctest/simple/src/main/scala/Main.scala
@@ -43,6 +43,10 @@ object Main {
    * {{{
    * scala> Main.list.take(2)
    * res0: List[Int] = List(0, 1)
+   *
+   * scala> val xs = List(2)
+   * scala> 1 :: xs
+   * res0: List[Int] = List(1, 2)
    * }}}
    */
   def list: List[Int] = List.range(0, 5)

--- a/src/test/scala/com/github/tkawachi/doctest/CommentParserSpec.scala
+++ b/src/test/scala/com/github/tkawachi/doctest/CommentParserSpec.scala
@@ -53,7 +53,14 @@ class CommentParserSpec extends FunSpec with Matchers {
       val comment =
         """ * >>> import abc.def
         """.stripMargin
-      parse(comment).get should equal(List(Import("import abc.def")))
+      parse(comment).get should equal(List(VerbatimLine("import abc.def")))
+    }
+
+    it("parses a val") {
+      val comment =
+        """ * >>> val x = 1
+        """.stripMargin
+      parse(comment).get should equal(List(VerbatimLine("val x = 1")))
     }
   }
 
@@ -103,7 +110,14 @@ class CommentParserSpec extends FunSpec with Matchers {
       val comment =
         """ * scala> import abc.def
         """.stripMargin
-      parse(comment).get should equal(List(Import("import abc.def")))
+      parse(comment).get should equal(List(VerbatimLine("import abc.def")))
+    }
+
+    it("parses a val") {
+      val comment =
+        """ * scala> val x = 1
+        """.stripMargin
+      parse(comment).get should equal(List(VerbatimLine("val x = 1")))
     }
 
     it("parses a result with a parametric type") {
@@ -114,7 +128,7 @@ class CommentParserSpec extends FunSpec with Matchers {
       parse(comment).get should equal(List(Example("List(1)", TestResult("List(1)", Some("List[Int]")), 1)))
     }
 
-    it("parses a type with a colon") {
+    it("parses a type with an equal sign") {
       val comment =
         """ * scala> =:=
           | * res0: =:=.type = scala.Predef...
@@ -145,7 +159,14 @@ class CommentParserSpec extends FunSpec with Matchers {
       val comment =
         """ * prop> import abc.def
         """.stripMargin
-      parse(comment).get should equal(List(Import("import abc.def")))
+      parse(comment).get should equal(List(VerbatimLine("import abc.def")))
+    }
+
+    it("parses a val") {
+      val comment =
+        """ * prop> val x = 1
+        """.stripMargin
+      parse(comment).get should equal(List(VerbatimLine("val x = 1")))
     }
   }
 


### PR DESCRIPTION
This is an attempt to implemet #10 (supporting `val` and `var` statements). I've renamed the `Import` case of `DoctestComponent` to `VerbatimLine` and use it to also support assignments. That means that `val`s are in the same scope as the imports (inside the `describe` but not inside the `it`). So you can't use two `val`s with the same name in one Scaladoc. This would yield a compile error:

``` scala
/**
 * {{{
 * >>> val x = 1
 * ...
 * >>> val x = 2
 * }}}
 */
```
