### PR TITLE
Show the name of the documented symbol

### DIFF
--- a/src/main/scala/com/github/tkawachi/doctest/CommentParser.scala
+++ b/src/main/scala/com/github/tkawachi/doctest/CommentParser.scala
@@ -84,7 +84,7 @@ object CommentParser extends RegexParsers {
   def parse(input: String) = parseAll(lines, input)
 
   def apply(comment: ScaladocComment): Either[String, ParsedDoctest] = parse(comment.text) match {
-    case Success(examples, _) => Right(ParsedDoctest(comment.pkg, examples, comment.lineno))
+    case Success(examples, _) => Right(ParsedDoctest(comment.pkg, comment.symbol, examples, comment.lineno))
     case NoSuccess(msg, next) => Left(s"$msg on line ${next.pos.line}, column ${next.pos.column}")
   }
 

--- a/src/main/scala/com/github/tkawachi/doctest/ParsedDoctest.scala
+++ b/src/main/scala/com/github/tkawachi/doctest/ParsedDoctest.scala
@@ -1,3 +1,3 @@
 package com.github.tkawachi.doctest
 
-case class ParsedDoctest(pkg: Option[String], components: Seq[DoctestComponent], lineno: Int)
+case class ParsedDoctest(pkg: Option[String], symbol: String, components: Seq[DoctestComponent], lineno: Int)

--- a/src/main/scala/com/github/tkawachi/doctest/ScalaTestGen.scala
+++ b/src/main/scala/com/github/tkawachi/doctest/ScalaTestGen.scala
@@ -25,7 +25,7 @@ object ScalaTestGen extends TestGen {
   }
 
   def generateIt(basename: String, parsed: ParsedDoctest): String = {
-    s"""  describe("${escapeDQ(basename)}.scala:${parsed.lineno}") {
+    s"""  describe("${escapeDQ(basename)}.scala:${parsed.lineno}: ${parsed.symbol}") {
        |${parsed.components.map(gen(basename, parsed.lineno, _)).mkString("\n\n")}
        |  }""".stripMargin
   }

--- a/src/main/scala/com/github/tkawachi/doctest/ScaladocComment.scala
+++ b/src/main/scala/com/github/tkawachi/doctest/ScaladocComment.scala
@@ -1,3 +1,3 @@
 package com.github.tkawachi.doctest
 
-case class ScaladocComment(pkg: Option[String], text: String, lineno: Int)
+case class ScaladocComment(pkg: Option[String], symbol: String, text: String, lineno: Int)

--- a/src/test/resources/RootPackage.scala
+++ b/src/test/resources/RootPackage.scala
@@ -15,3 +15,11 @@ package a1 {
 
 /** Root2 */
 class Root2
+
+object Root3 {
+  /** Method2 comment */
+  def method2 = ???
+
+  /** Type alias */
+  type IntAlias = Int
+}

--- a/src/test/scala/com/github/tkawachi/doctest/ExtractorSpec.scala
+++ b/src/test/scala/com/github/tkawachi/doctest/ExtractorSpec.scala
@@ -11,8 +11,8 @@ class ExtractorSpec extends FunSpec with Matchers with BeforeAndAfter {
     val src = Source.fromFile("src/test/resources/Test.scala").mkString
     extractor.extract(src) should equal(
       List(
-        ScaladocComment(None, "/**\n * Test class\n */", 1),
-        ScaladocComment(None,
+        ScaladocComment(None, "Test", "/**\n * Test class\n */", 1),
+        ScaladocComment(None, "f",
           """/**
           |   * A function.
           |   *
@@ -30,11 +30,13 @@ class ExtractorSpec extends FunSpec with Matchers with BeforeAndAfter {
     val src = Source.fromFile("src/test/resources/RootPackage.scala").mkString
     extractor.extract(src) should equal(
       List(
-        ScaladocComment(None, "/** Class comment */", 1),
-        ScaladocComment(None, "/** Method comment */", 3),
-        ScaladocComment(Some("a1"), "/** A1 */", 8),
-        ScaladocComment(Some("a1.b1"), "/** B1 */", 11),
-        ScaladocComment(None, "/** Root2 */", 16)
+        ScaladocComment(None, "Root1", "/** Class comment */", 1),
+        ScaladocComment(None, "method", "/** Method comment */", 3),
+        ScaladocComment(Some("a1"), "A1", "/** A1 */", 8),
+        ScaladocComment(Some("a1.b1"), "B1", "/** B1 */", 11),
+        ScaladocComment(None, "Root2", "/** Root2 */", 16),
+        ScaladocComment(None, "method2", "/** Method2 comment */", 20),
+        ScaladocComment(None, "IntAlias", "/** Type alias */", 23)
       )
     )
   }
@@ -43,11 +45,11 @@ class ExtractorSpec extends FunSpec with Matchers with BeforeAndAfter {
     val src = Source.fromFile("src/test/resources/Package.scala").mkString
     extractor.extract(src) should equal(
       List(
-        ScaladocComment(Some("some.pkg"), "/** Class comment */", 3),
-        ScaladocComment(Some("some.pkg"), "/** Method comment */", 5),
-        ScaladocComment(Some("some.pkg.a1"), "/** A1 */", 10),
-        ScaladocComment(Some("some.pkg.a1.b1"), "/** B1 */", 13),
-        ScaladocComment(Some("some.pkg"), "/** Root2 */", 18)
+        ScaladocComment(Some("some.pkg"), "Root1", "/** Class comment */", 3),
+        ScaladocComment(Some("some.pkg"), "method", "/** Method comment */", 5),
+        ScaladocComment(Some("some.pkg.a1"), "A1", "/** A1 */", 10),
+        ScaladocComment(Some("some.pkg.a1.b1"), "B1", "/** B1 */", 13),
+        ScaladocComment(Some("some.pkg"), "Root2", "/** Root2 */", 18)
       )
     )
   }


### PR DESCRIPTION
This shows the name of the documented symbol in the test output:

```
[info] MainDoctest:
[info] Main.scala:4: f
[info] - Main.scala:8
[info] - Main.scala:11
[info] Main.scala:18: xyz
[info] - Main.scala:25
[info] Main.scala:31: abc
[info] - Main.scala:36
[info] Main.scala:42: list
[info] - Main.scala:44
```

Instead of only filenames and linenumbers as it is now:

```
[info] MainDoctest:
[info] Main.scala:4
[info] - Main.scala:8
[info] - Main.scala:11
[info] Main.scala:18
[info] - Main.scala:25
[info] Main.scala:31
[info] - Main.scala:36
[info] Main.scala:42
[info] - Main.scala:44
```
