### PR TITLE
Use fully qualified types to prevent name clashes

### DIFF
--- a/src/main/scala/com/github/tkawachi/doctest/ScalaTestGen.scala
+++ b/src/main/scala/com/github/tkawachi/doctest/ScalaTestGen.scala
@@ -9,12 +9,13 @@ object ScalaTestGen extends TestGen {
     val pkgLine = pkg.fold("")(p => s"package $p")
     s"""$pkgLine
        |
-       |import org.scalatest.{ Matchers, FunSpec }
-       |import org.scalatest.prop.PropertyChecks
        |import org.scalacheck.Arbitrary._
        |import org.scalacheck.Prop._
        |
-       |class ${basename}Doctest extends FunSpec with Matchers with PropertyChecks {
+       |class ${basename}Doctest
+       |    extends org.scalatest.FunSpec
+       |    with org.scalatest.Matchers
+       |    with org.scalatest.prop.PropertyChecks {
        |
        |  def sbtDoctestGetType[A: $ru.TypeTag](a: A): $ru.Type =
        |    $ru.typeOf[A]


### PR DESCRIPTION
If there are types like `FunSpec`, `Matchers`, or `PropertyChecks` defined in the package that the generated tests are put into (like `sbt_test` in the test project), the tests won't compile because those types clash with the imports from ScalaTest. This PR prevents these situations by using ScalaTest types fully qualified.
