### PR TITLE
Support more declarations

### DIFF
--- a/src/main/scala/com/github/tkawachi/doctest/CommentParser.scala
+++ b/src/main/scala/com/github/tkawachi/doctest/CommentParser.scala
@@ -50,7 +50,8 @@ trait GenericParser extends RegexParsers {
     }
 
   private val verbatimBegin = {
-    val keywords = "def" | "import" | "val" | "var"
+    val keywords = "abstract" | "case" | "class" | "def" | "implicit" | "import" |
+      "lazy" | "object" | "sealed" | "trait" | "type" | "val" | "var"
     val whiteSpacePlusAnyStr = horizontalWhiteSpace ~ anyStr ^^ append
     keywords ~ (whiteSpacePlusAnyStr | emptyStr) ^^ PositionedString.compose(append)
   }

--- a/src/sbt-test/sbt-doctest/simple/src/main/scala/Main.scala
+++ b/src/sbt-test/sbt-doctest/simple/src/main/scala/Main.scala
@@ -71,7 +71,7 @@ object Main {
    * res1: String = ""
    *
    * scala> "a a"
-   * res3: String = a a
+   * res2: String = a a
    *
    * scala> "a "
    * res3: String = "a "

--- a/src/sbt-test/sbt-doctest/simple/src/main/scala/VerbatimTest.scala
+++ b/src/sbt-test/sbt-doctest/simple/src/main/scala/VerbatimTest.scala
@@ -1,0 +1,72 @@
+package sbt_doctest
+
+object VerbatimTest {
+
+  /**
+   * scala> abstract class A {
+   *      |   def name: String
+   *      | }
+   * scala> class B extends A {
+   *      |   def name = "B"
+   *      | }
+   * scala> (new B).name
+   * res0: String = B
+   */
+  abstract class A1
+
+  /**
+   * {{{
+   * scala> case class C(name: String)
+   * scala> C("Hello").name
+   * res0: String = Hello
+   * }}}
+   */
+  case class C1()
+
+  /**
+   * >>> class C { def name = "clazz" }
+   * >>> (new C).name
+   * clazz
+   */
+  class C2
+
+  /**
+   * >>> implicit val y = 23
+   * >>> def f(implicit ev: Int) = ev
+   * >>> f
+   * 23
+   */
+  implicit val x: Int = 42
+
+  /**
+   * scala> object xy { val z = 123 }
+   * scala> xy.z
+   * res0: Int = 123
+   */
+  object obj
+
+  /**
+   * >>> sealed trait ST1
+   * >>> case object ST2 extends ST1 { val x = 9 }
+   * >>> ST2.x
+   * 9
+   */
+  sealed trait T3
+
+  /**
+   * >>> trait T1
+   * >>> object T2 extends T1 { val x = 19 }
+   * >>> T2.x
+   * 19
+   */
+  trait T4
+
+  /**
+   * scala> type
+   *      |   MyInt = Int
+   * scala> val x: MyInt = 4
+   * scala> x: Int
+   * res0: Int = 4
+   */
+  type MyInt = Int
+}


### PR DESCRIPTION
This PR allows additional declarations that are copied verbatim into the tests. Additional keywords that start a `Verbatim` section are: `abstract`, `case`, `class`, `implicit`, `lazy` `object`, `sealed`, `trait`, and `type`
