### PR TITLE
Bump sbt 0.13.2 to 0.13.7

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,8 +41,8 @@ Set `doctestWithDependencies` to `false` when you explicitly specify testing lib
 doctestWithDependencies := false
 
 libraryDependencies ++= Seq(
-  "org.scalatest" %% "scalatest" % "2.2.0" % "test",
-  "org.scalacheck" %% "scalacheck" % "1.11.4" % "test"
+  "org.scalatest"  %% "scalatest"  % "2.2.3"  % "test",
+  "org.scalacheck" %% "scalacheck" % "1.12.1" % "test"
   // And other library dependencies.
 )
 ```

--- a/build.sbt
+++ b/build.sbt
@@ -1,36 +1,27 @@
-sbtPlugin := true
-
-name := "sbt-doctest"
-
-organization := "com.github.tkawachi"
-
-licenses := Seq("MIT" -> url("http://opensource.org/licenses/MIT"))
-
-scmInfo := Some(ScmInfo(
-  url("https://github.com/tkawachi/sbt-doctest/"),
-  "scm:git:github.com:tkawachi/sbt-doctest.git"
-))
-
-scalaVersion := "2.10.4"
-
-scalacOptions ++= Seq(
-  "-deprecation",
-  "-encoding", "UTF-8",
-  "-feature",
-  "-unchecked",
-  "-Xfatal-warnings",
-  "-Xlint"
-)
-
-libraryDependencies ++= Seq(
-  "org.scala-lang" % "scala-compiler" % scalaVersion.value,
-  "org.scalatest" %% "scalatest" % "2.2.0" % "test",
-  "org.scalacheck" %% "scalacheck" % "1.11.4" % "test",
-  "commons-io" % "commons-io" % "2.4"
-)
-
-scalariformSettings
-
-doctestSettings
-
-doctestTestFramework := DoctestTestFramework.ScalaTest
+lazy val root = (project in file(".")).settings(
+  sbtPlugin := true,
+  organization := "com.github.tkawachi",
+  name := "sbt-doctest",
+  licenses := Seq("MIT" -> url("http://opensource.org/licenses/MIT")),
+  scmInfo := Some(ScmInfo(
+    url("https://github.com/tkawachi/sbt-doctest/"),
+    "scm:git:github.com:tkawachi/sbt-doctest.git"
+  )),
+  scalaVersion := "2.10.4",
+  scalacOptions ++= Seq(
+    "-deprecation",
+    "-encoding", "UTF-8",
+    "-feature",
+    "-unchecked",
+    "-Xfatal-warnings",
+    "-Xlint"
+  ),
+  libraryDependencies ++= Seq(
+    "org.scala-lang" %  "scala-compiler" % scalaVersion.value,
+    "org.scalatest"  %% "scalatest"      % "2.2.3"  % "test",
+    "org.scalacheck" %% "scalacheck"     % "1.12.1" % "test",
+    "commons-io"     %  "commons-io"     % "2.4"
+  ),
+  doctestTestFramework := DoctestTestFramework.ScalaTest
+).settings(scalariformSettings: _*)
+ .settings(doctestSettings: _*)

--- a/lock.sbt
+++ b/lock.sbt
@@ -53,4 +53,4 @@ dependencyOverrides in ThisBuild ++= Set(
   "org.scalacheck" % "scalacheck_2.10" % "1.11.6",
   "org.scalatest" % "scalatest_2.10" % "2.2.0"
 )
-// LIBRARY_DEPENDENCIES_HASH f19df6add5d224271eb27e4d28e25f71a5b688ff
+// LIBRARY_DEPENDENCIES_HASH d6bf3180f39acceaf1557c3f50fd864ba6e87afc

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.2
+sbt.version=0.13.7

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,13 +1,9 @@
 libraryDependencies += "org.scala-sbt" % "scripted-plugin" % sbtVersion.value
 
-addSbtPlugin("com.typesafe.sbt" % "sbt-scalariform" % "1.3.0")
-
-addSbtPlugin("com.github.tkawachi" % "sbt-lock" % "0.2.2")
-
-addSbtPlugin("com.github.gseitz" % "sbt-release" % "0.8.2")
-
-addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "0.2.1")
-
-addSbtPlugin("com.typesafe.sbt" % "sbt-pgp" % "0.8.1")
-
-addSbtPlugin("com.github.tkawachi" % "sbt-doctest" % "0.3.3")
+addSbtPlugin("com.typesafe.sbt"    % "sbt-scalariform" % "1.3.0")
+addSbtPlugin("com.github.tkawachi" % "sbt-lock"        % "0.2.2")
+addSbtPlugin("com.timushev.sbt"    % "sbt-updates"     % "0.1.7")
+addSbtPlugin("com.github.gseitz"   % "sbt-release"     % "0.8.2")
+addSbtPlugin("org.xerial.sbt"      % "sbt-sonatype"    % "0.2.1")
+addSbtPlugin("com.jsuereth"        % "sbt-pgp"         % "1.0.0")
+addSbtPlugin("com.github.tkawachi" % "sbt-doctest"     % "0.3.3")

--- a/src/main/scala/com/github/tkawachi/doctest/DoctestPlugin.scala
+++ b/src/main/scala/com/github/tkawachi/doctest/DoctestPlugin.scala
@@ -35,12 +35,9 @@ object DoctestPlugin extends Plugin {
    * Default libraryDependencies.
    */
   object TestLibs {
-    val scalacheck = Seq("org.scalacheck" %% "scalacheck" % "1.11.6" % "test")
-
-    val scalatest = Seq("org.scalatest" %% "scalatest" % "2.2.0" % "test") ++ scalacheck
-
-    val specs2Version = "2.4.4"
-
+    val scalacheck = Seq("org.scalacheck" %% "scalacheck" % "1.12.1" % "test")
+    val scalatest = Seq("org.scalatest" %% "scalatest" % "2.2.3" % "test") ++ scalacheck
+    val specs2Version = "2.4.15"
     val specs2 = Seq(
       "org.specs2" %% "specs2-core" % specs2Version % "test",
       "org.specs2" %% "specs2-scalacheck" % specs2Version % "test"


### PR DESCRIPTION
- sbt 0.13.7 (we don't need empty lines any more)
- bump scalatest, scalacheck 
- add sbt-updates plugin to easily check latest dependency version
